### PR TITLE
Net: limit number of nodes in NodesMessage

### DIFF
--- a/src/main/java/org/semux/api/ApiHandlerImpl.java
+++ b/src/main/java/org/semux/api/ApiHandlerImpl.java
@@ -7,7 +7,6 @@
 package org.semux.api;
 
 import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -47,6 +46,7 @@ import org.semux.core.state.Delegate;
 import org.semux.crypto.CryptoException;
 import org.semux.crypto.EdDSA;
 import org.semux.crypto.Hex;
+import org.semux.net.NodeManager;
 import org.semux.util.exception.UnreachableException;
 
 import io.netty.handler.codec.http.HttpHeaders;
@@ -199,7 +199,7 @@ public class ApiHandlerImpl implements ApiHandler {
      *            node parameter of /add_node API
      * @return validated hostname and port number
      */
-    private InetSocketAddress validateAddNodeParameter(String node) {
+    private NodeManager.Node validateAddNodeParameter(String node) {
         if (node == null || node.length() == 0) {
             throw new IllegalArgumentException("Parameter `node` can't be empty");
         }
@@ -210,8 +210,10 @@ public class ApiHandlerImpl implements ApiHandler {
         }
 
         try {
-            return new InetSocketAddress(InetAddress.getByName(matcher.group("host")),
-                    Integer.parseInt(matcher.group("port")));
+            return new NodeManager.Node( //
+                    InetAddress.getByName(matcher.group("host")), //
+                    Integer.parseInt(matcher.group("port")) //
+            ); //
         } catch (UnknownHostException e) {
             throw new IllegalArgumentException(e.getMessage(), e);
         }

--- a/src/main/java/org/semux/config/AbstractConfig.java
+++ b/src/main/java/org/semux/config/AbstractConfig.java
@@ -8,7 +8,6 @@ package org.semux.config;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -18,6 +17,7 @@ import java.util.Set;
 
 import org.semux.core.Unit;
 import org.semux.crypto.Hash;
+import org.semux.net.NodeManager;
 import org.semux.net.msg.MessageCode;
 import org.semux.util.Bytes;
 import org.semux.util.StringUtil;
@@ -50,7 +50,7 @@ public abstract class AbstractConfig implements Config {
     protected String p2pDeclaredIp = null;
     protected String p2pListenIp = "0.0.0.0";
     protected int p2pListenPort = Constants.DEFAULT_P2P_PORT;
-    protected Set<InetSocketAddress> p2pSeedNodes = new HashSet<>();
+    protected Set<NodeManager.Node> p2pSeedNodes = new HashSet<>();
 
     // =========================
     // Network
@@ -204,7 +204,7 @@ public abstract class AbstractConfig implements Config {
     }
 
     @Override
-    public Set<InetSocketAddress> p2pSeedNodes() {
+    public Set<NodeManager.Node> p2pSeedNodes() {
         return p2pSeedNodes;
     }
 
@@ -353,9 +353,9 @@ public abstract class AbstractConfig implements Config {
                     for (String node : nodes) {
                         String[] tokens = node.trim().split(":");
                         if (tokens.length == 2) {
-                            p2pSeedNodes.add(new InetSocketAddress(tokens[0], Integer.parseInt(tokens[1])));
+                            p2pSeedNodes.add(new NodeManager.Node(tokens[0], Integer.parseInt(tokens[1])));
                         } else {
-                            p2pSeedNodes.add(new InetSocketAddress(tokens[0], Constants.DEFAULT_P2P_PORT));
+                            p2pSeedNodes.add(new NodeManager.Node(tokens[0], Constants.DEFAULT_P2P_PORT));
                         }
                     }
                     break;

--- a/src/main/java/org/semux/config/Config.java
+++ b/src/main/java/org/semux/config/Config.java
@@ -7,11 +7,11 @@
 package org.semux.config;
 
 import java.io.File;
-import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import org.semux.net.NodeManager;
 import org.semux.net.msg.MessageCode;
 
 /**
@@ -147,7 +147,7 @@ public interface Config {
      * 
      * @return
      */
-    Set<InetSocketAddress> p2pSeedNodes();
+    Set<NodeManager.Node> p2pSeedNodes();
 
     // =========================
     // Network

--- a/src/main/java/org/semux/net/SemuxP2pHandler.java
+++ b/src/main/java/org/semux/net/SemuxP2pHandler.java
@@ -6,12 +6,15 @@
  */
 package org.semux.net;
 
+import static org.semux.net.msg.p2p.NodesMessage.MAX_NODES;
+
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import org.semux.Kernel;
 import org.semux.config.Config;
@@ -215,7 +218,9 @@ public class SemuxP2pHandler extends SimpleChannelInboundHandler<Message> {
             break;
         }
         case GET_NODES: {
-            NodesMessage nodesMsg = new NodesMessage(channelMgr.getActiveAddresses());
+            NodesMessage nodesMsg = new NodesMessage(
+                    channelMgr.getActiveAddresses().stream().limit(MAX_NODES).map(NodeManager.Node::new).collect(
+                            Collectors.toSet()));
             msgQueue.sendMessage(nodesMsg);
             break;
         }

--- a/src/main/java/org/semux/net/msg/p2p/NodesMessage.java
+++ b/src/main/java/org/semux/net/msg/p2p/NodesMessage.java
@@ -10,6 +10,7 @@ import java.net.InetSocketAddress;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.semux.net.NodeManager;
 import org.semux.net.msg.Message;
 import org.semux.net.msg.MessageCode;
 import org.semux.util.SimpleDecoder;
@@ -17,14 +18,20 @@ import org.semux.util.SimpleEncoder;
 
 public class NodesMessage extends Message {
 
-    private Set<InetSocketAddress> nodes;
+    public static final int MAX_NODES = 128;
+
+    private Set<NodeManager.Node> nodes;
+
+    public NodesMessage() {
+        super(MessageCode.NODES, null);
+    }
 
     /**
      * Create a NODES message.
      * 
      * @param nodes
      */
-    public NodesMessage(Set<InetSocketAddress> nodes) {
+    public NodesMessage(Set<NodeManager.Node> nodes) {
         super(MessageCode.NODES, null);
 
         this.nodes = nodes;
@@ -50,15 +57,15 @@ public class NodesMessage extends Message {
 
         nodes = new HashSet<>();
         SimpleDecoder dec = new SimpleDecoder(encoded);
-        int n = dec.readInt();
+        int n = Math.min(dec.readInt(), MAX_NODES);
         for (int i = 0; i < n; i++) {
             String host = dec.readString();
             int port = dec.readInt();
-            nodes.add(new InetSocketAddress(host, port));
+            nodes.add(new NodeManager.Node(host, port));
         }
     }
 
-    public Set<InetSocketAddress> getNodes() {
+    public Set<NodeManager.Node> getNodes() {
         return nodes;
     }
 

--- a/src/test/java/org/semux/integration/TransferTest.java
+++ b/src/test/java/org/semux/integration/TransferTest.java
@@ -100,9 +100,11 @@ public class TransferTest {
         when(Genesis.load(any())).thenReturn(genesis);
 
         // mock seed nodes
-        Set<InetSocketAddress> nodes = new HashSet<>();
-        nodes.add(new InetSocketAddress(InetAddress.getByName(kernelValidator.getConfig().p2pListenIp()),
-                kernelValidator.getConfig().p2pListenPort()));
+        Set<NodeManager.Node> nodes = new HashSet<>();
+        nodes.add(new NodeManager.Node( //
+            InetAddress.getByName(kernelValidator.getConfig().p2pListenIp()), //
+            kernelValidator.getConfig().p2pListenPort() //
+        ));
         mockStatic(NodeManager.class);
         when(NodeManager.getSeedNodes(Constants.DEV_NET_ID)).thenReturn(nodes);
 

--- a/src/test/java/org/semux/integration/TransferTest.java
+++ b/src/test/java/org/semux/integration/TransferTest.java
@@ -102,8 +102,8 @@ public class TransferTest {
         // mock seed nodes
         Set<NodeManager.Node> nodes = new HashSet<>();
         nodes.add(new NodeManager.Node( //
-            InetAddress.getByName(kernelValidator.getConfig().p2pListenIp()), //
-            kernelValidator.getConfig().p2pListenPort() //
+                InetAddress.getByName(kernelValidator.getConfig().p2pListenIp()), //
+                kernelValidator.getConfig().p2pListenPort() //
         ));
         mockStatic(NodeManager.class);
         when(NodeManager.getSeedNodes(Constants.DEV_NET_ID)).thenReturn(nodes);

--- a/src/test/java/org/semux/net/NodeManagerTest.java
+++ b/src/test/java/org/semux/net/NodeManagerTest.java
@@ -50,7 +50,7 @@ public class NodeManagerTest {
     @Test
     public void testGetSeedNodes() {
         // Seed nodes for main net
-        Set<InetSocketAddress> peers = NodeManager.getSeedNodes(Constants.MAIN_NET_ID);
+        Set<NodeManager.Node> peers = NodeManager.getSeedNodes(Constants.MAIN_NET_ID);
         assertFalse(peers.isEmpty());
 
         // Seed nodes for test net
@@ -69,7 +69,7 @@ public class NodeManagerTest {
 
         KernelMock kernel2 = kernelRule2.getKernel();
         NodeManager nodeMgr = kernel2.getNodeManager();
-        nodeMgr.addNode(new InetSocketAddress("127.0.0.1", server1.getKernel().getConfig().p2pListenPort()));
+        nodeMgr.addNode(new NodeManager.Node("127.0.0.1", server1.getKernel().getConfig().p2pListenPort()));
         nodeMgr.doConnect();
 
         Thread.sleep(500);

--- a/src/test/java/org/semux/net/msg/p2p/NodesMessageTest.java
+++ b/src/test/java/org/semux/net/msg/p2p/NodesMessageTest.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2017 The Semux Developers
+ *
+ * Distributed under the MIT software license, see the accompanying file
+ * LICENSE or https://opensource.org/licenses/mit-license.php
+ */
+package org.semux.net.msg.p2p;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertArrayEquals;
+import static org.semux.net.msg.p2p.NodesMessage.MAX_NODES;
+
+import java.net.InetSocketAddress;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+import org.semux.net.NodeManager;
+import org.semux.util.SimpleEncoder;
+
+public class NodesMessageTest {
+
+    @Test
+    public void testCodec() {
+        Set<NodeManager.Node> nodes = new HashSet<>();
+        nodes.add(new NodeManager.Node(new InetSocketAddress("127.0.0.1", 5160)));
+        nodes.add(new NodeManager.Node(new InetSocketAddress("127.0.0.1", 5161)));
+        NodesMessage nodesMessage = new NodesMessage(new NodesMessage(nodes).getEncoded());
+        assertArrayEquals(nodes.toArray(), nodesMessage.getNodes().toArray());
+    }
+
+    @Test
+    public void testOverflow() {
+        MaliciousNodesMessage maliciousNodesMessage = new MaliciousNodesMessage();
+        byte[] bytes = maliciousNodesMessage.getEncoded();
+        NodesMessage nodesMessage = new NodesMessage(bytes);
+        assertEquals(MAX_NODES, nodesMessage.getNodes().size());
+    }
+
+    private class MaliciousNodesMessage extends NodesMessage {
+
+        public MaliciousNodesMessage() {
+            super();
+            SimpleEncoder enc = new SimpleEncoder();
+            enc.writeInt(MAX_NODES + 1);
+            for (int i = 0; i < MAX_NODES + 1; i++) {
+                enc.writeString("www.google.com");
+                enc.writeInt(i + 1);
+            }
+            this.encoded = enc.toBytes();
+        }
+    }
+}


### PR DESCRIPTION
NodeManager may be vulnerable to DoS when a malicious peer sends a large number of nodes